### PR TITLE
마크다운 이미지에 figcaption 추가

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,6 +23,7 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
+import rehypeFigure from "rehype-figure";
 
 // https://astro.build/config
 export default defineConfig({
@@ -75,7 +76,12 @@ export default defineConfig({
       wrap: true,
     },
     remarkPlugins: [remarkMath],
-    rehypePlugins: [rehypeKatex, rehypeAutolinkHeadings, rehypeSlug],
+    rehypePlugins: [
+      rehypeKatex,
+      rehypeAutolinkHeadings,
+      rehypeSlug,
+      rehypeFigure,
+    ],
   },
 
   prefetch: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "astro-og-canvas": "^0.5.4",
         "lite-youtube-embed": "^0.3.3",
         "rehype-autolink-headings": "^7.1.0",
+        "rehype-figure": "^1.0.1",
         "rehype-katex": "^7.0.1",
         "rehype-slug": "^6.0.0",
         "remark-math": "^6.0.0",
@@ -6552,6 +6553,119 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-figure": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-figure/-/rehype-figure-1.0.1.tgz",
+      "integrity": "sha512-g7DJuK8R8xHIaPI3QJ6/OoWiKepn92RF2CV3z4dO7lRO6ZHo48Tu9X3KgnZUKK035srFHqWQx93AybBy12XqmQ==",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "unist-util-visit": "^2.0.3"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+    },
+    "node_modules/rehype-figure/node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-figure/node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-katex": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
@@ -8333,6 +8447,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "astro-og-canvas": "^0.5.4",
     "lite-youtube-embed": "^0.3.3",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-figure": "^1.0.1",
     "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
     "remark-math": "^6.0.0",

--- a/src/content/blog/2021-07-26-boostcamp-ai-tech-1st.mdx
+++ b/src/content/blog/2021-07-26-boostcamp-ai-tech-1st.mdx
@@ -27,7 +27,7 @@ noTextInOGImage: true
 
 ### 교육 목적과 교과 과정
 
-![https://boostcamp.connect.or.kr/program_ai.html|부스트캠프 AI Tech 프로그램 소개]($assets/img/2021-07-26-boostcamp-ai-tech-1st/education-purpose.png)
+![부스트캠프 AI Tech 프로그램 소개]($assets/img/2021-07-26-boostcamp-ai-tech-1st/education-purpose.png)
 
 부스트캠프 AI Tech 1기의 교육 목표는 인공지능과 딥러닝을 어떻게 활용해야 하는지 명확히 알고 서비스에 적용하는 것입니다. 2기도 크게 다르지 않지만, AI Production의 End-to-End 경험이라는 부분이 추가되었습니다. 즉, 연구보다는 **서비스 개발에 초점을 맞춘 AI 엔지니어를 양성하는 것**이 목적입니다.
 
@@ -37,7 +37,7 @@ noTextInOGImage: true
 
 ### 이론 중심 교육 U Stage
 
-![https://boostcamp.connect.or.kr/program_ai.html|부스트캠프 AI Tech 프로그램 소개]($assets/img/2021-07-26-boostcamp-ai-tech-1st/instructor.png)
+![부스트캠프 AI Tech 프로그램 소개]($assets/img/2021-07-26-boostcamp-ai-tech-1st/instructor.png)
 
 U Stage는 **인공지능 기초 지식을 쌓는 기간**입니다. 이론 강의는 대부분 교수님께서 가르치시고 시중에 있는 인공지능 강의와 내용 구성이 크게 다르지 않습니다. 강의 뿐만 아니라 퀴즈나 빈칸에 코드를 채우는 과제도 있는데 강의 내용을 복습할 수 있어서 좋았습니다.
 
@@ -114,7 +114,7 @@ P Stage는 Stage 1과 Stage 2는 개인으로, Stage 3와 Stage 4는 팀으로 �
 
 #### 모델링 위주의 교육
 
-![https://developers.google.com/machine-learning/testing-debugging/pipeline/overview?hl=ko|Overview of ML Pipelines]($assets/img/2021-07-26-boostcamp-ai-tech-1st/machine-learning-pipeline.png)
+![Overview of ML Pipelines]($assets/img/2021-07-26-boostcamp-ai-tech-1st/machine-learning-pipeline.png)
 
 위의 사진은 인공지능 서비스를 만들 때의 파이프라인입니다. 보시는 것처럼 **모델링은 일부임**을 알 수 있습니다. 또한 인공지능 직무 채용 공고를 보시면 데이터 엔지니어, 데이터 사이언티스트, AI 애플리케이션 개발자 등 다양한 직무가 있는 것을 보실 수 있습니다.
 
@@ -122,7 +122,7 @@ P Stage는 Stage 1과 Stage 2는 개인으로, Stage 3와 Stage 4는 팀으로 �
 
 #### 짧았던 프로젝트 기간
 
-![http://gph.is/1e3gK2F]($assets/img/2021-07-26-boostcamp-ai-tech-1st/sleep-coding.gif)
+![]($assets/img/2021-07-26-boostcamp-ai-tech-1st/sleep-coding.gif)
 
 총 다섯 번의 대회를 경험하면서 가장 아쉬웠던 점은 **기간**이었습니다. 보통 데이터분석 대회 기간이 최소 한 달인 것을 생각하면 11일의 대회는 정말 숨막힐 정도였습니다.
 

--- a/src/content/blog/2023-02-25-catch-up.mdx
+++ b/src/content/blog/2023-02-25-catch-up.mdx
@@ -60,7 +60,7 @@ noTextInOGImage: true
 
 이 블로그를 보면 알겠지만, 작년에 이어 올해도 새로 블로그를 만들었다. 이전까지 `Tistory → Gatsby → Vuepress → Tistory`로 옮긴 유구한 역사가 있는데, Tistory로 다시 돌아갔던 이유는 GitHub에 개인 블로그를 만들면 해야 하는 설정이 많아서였다. 하지만, Tistory가 커스텀하기 쉽지 않고 마크다운 지원이 별로여서 [Docusaurus](https://docusaurus.io/ko/docs)로 다시 옮기게 되었다.
 
-![https://docusaurus.io|도큐사우루스 공식문서]($assets/img/2023-02-25-catch-up/docusaurus.png)
+![]($assets/img/2023-02-25-catch-up/docusaurus.png)
 
 블로그 포맷은 전에 만들었던 [VuePress](https://vuepress.vuejs.org/)와 비슷한데, [Vue](https://vuejs.org/)보다는 [React](https://ko.reactjs.org/)가 익숙해서 [Docusaurus](https://docusaurus.io/ko/docs)를 선택했다. 다른 계기로는 [Sunghyun Cho님의 블로그](https://cho.sh/)를 보고 나도 이 분처럼 블로그를 커스텀하고 싶어서 선택하게 됐다. `docusaurus.config.js`와 [Swizzling 기능](https://docusaurus.io/ko/docs/next/swizzling)을 써서 커스텀을 했고 나름대로 만족 중이다.
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -3,9 +3,14 @@ import ProseWrapper from "./ProseWrapper.astro";
 ---
 
 <style is:inline>
-  main img {
-    display: block;
-    margin: 0 auto;
+  main figure {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  main figure img {
     max-width: 100%;
     height: auto;
   }


### PR DESCRIPTION
* 기존 블로그에서는 alt text가 `<figcaption />`으로 변환해서 들어갔다.
* 이와 동일하게 맞추기 위해 [rehype-figure](https://github.com/Microflash/rehype-figure)를 추가하고 모든 이미지와 캡션이 가운데에 위치하도록 수정한다.
* 추후 링크가 들어가는 경우 외부 링크로 생성되도록 개선이 필요하다. 안 되면 직적 구현해서 넣을 것.