### PR TITLE
블로그 포스트 대표 이미지 여백 없애기

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -10,7 +10,7 @@ import ProseWrapper from "./ProseWrapper.astro";
     text-align: center;
   }
 
-  main figure img {
+  main figure > img {
     max-width: 100%;
     height: auto;
   }

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -42,7 +42,7 @@ if (replacedHero && !images[replacedHero])
         <Image
           src={images[replacedHero]()}
           alt=""
-          class="w-full h-80 object-cover rounded-xl shadow border border-base-400 dark:border-base-700"
+          class="w-full h-50 object-cover rounded-xl shadow border border-base-300 dark:border-base-800"
         />
       ) : null
     }


### PR DESCRIPTION
* 확인해보니 여백이 아니라 border 색이 튀어서 여백처럼 보이는 것임을 확인했다.
* border 색을 라이트 모드에서는 더 환하게 다크 모드에서는 더 어둡게 바꾸니 여백처럼 보이는 것이 없어졌다.